### PR TITLE
Fix for ESM modules imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "find-files-by-patterns-esm",
+  "name": "find-files-by-patterns",
   "sideEffects": false,
   "packageManager": "yarn@3.2.0",
   "version": "2.0.3",
@@ -8,11 +8,11 @@
   "author": "Marc-Antoine Ouimet <ouimetmarcantoine@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/devunion/find-files-by-patterns-esm.git"
+    "url": "https://github.com/MartyO256/find-files-by-patterns.git"
   },
-  "homepage": "https://github.com/devunion/find-files-by-patterns-esm#readme",
+  "homepage": "https://github.com/MartyO256/find-files-by-patterns#readme",
   "bugs": {
-    "url": "https://github.com/devunion/find-files-by-patterns-esm/issues",
+    "url": "https://github.com/MartyO256/find-files-by-patterns/issues",
     "email": "ouimetmarcantoine@gmail.com"
   },
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "find-files-by-patterns",
+  "name": "find-files-by-patterns-esm",
   "sideEffects": false,
   "packageManager": "yarn@3.2.0",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Find files by patterns in directories, upwards or downwards from other paths.",
   "license": "MIT",
   "author": "Marc-Antoine Ouimet <ouimetmarcantoine@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MartyO256/find-files-by-patterns.git"
+    "url": "https://github.com/devunion/find-files-by-patterns-esm.git"
   },
-  "homepage": "https://github.com/MartyO256/find-files-by-patterns#readme",
+  "homepage": "https://github.com/devunion/find-files-by-patterns-esm#readme",
   "bugs": {
-    "url": "https://github.com/MartyO256/find-files-by-patterns/issues",
+    "url": "https://github.com/devunion/find-files-by-patterns-esm/issues",
     "email": "ouimetmarcantoine@gmail.com"
   },
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,8 @@ export {
   onlyElement,
   onlyElementSync,
   ConflictError,
-} from "./iterable";
-export { readdir, readdirSync, readdirs, readdirsSync } from "./readdirs";
+} from "./iterable.js";
+export { readdir, readdirSync, readdirs, readdirsSync } from "./readdirs.js";
 
 export {
   hasPathSegments,
@@ -26,9 +26,9 @@ export {
   ofName,
   ofExtname,
   segments,
-} from "./path";
+} from "./path.js";
 export { isFile, isDirectory, isFileSync, isDirectorySync } from "./stat.js";
-export { hasFile, hasFileSync } from "./hasFile";
+export { hasFile, hasFileSync } from "./hasFile.js";
 
 export {
   findAllFiles,
@@ -37,7 +37,7 @@ export {
   findFileSync,
   findOnlyFile,
   findOnlyFileSync,
-} from "./fileFinders";
+} from "./fileFinders.js";
 
 export {
   downwardFiles,
@@ -50,4 +50,4 @@ export {
   downwardDirectoriesSync,
   upwardDirectories,
   upwardDirectoriesSync,
-} from "./directories";
+} from "./directories.js";


### PR DESCRIPTION
Fix for imports. Right now it fails with esbuild:

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '***\node_modules\find-files-by-patterns\lib\iterable' imported from ***\node_modules\find-files-by-patterns\lib\inde
x.js
